### PR TITLE
v0.0.19 : init TargetSystem, DropMenu.

### DIFF
--- a/Docs/roadmap.md
+++ b/Docs/roadmap.md
@@ -11,8 +11,12 @@ NEXT:
     INTERFACE:
         [ ] 250     Meilleure communication des actions possibles + boutons (ex: perso sur item : "(g) pick up {item}"
         [ ] 250     Afficher les objets et les personnages "en vue" avec description dans l'interface.
-        [ ] 100     Afficher items equipés dans menu Inventaire & Character?
+        [/] 100     Afficher items equipés dans menu Inventaire & Character?
         [ ] 100     Afficher les caracts des items equipés.
+        [ ] 100     Afficher les objets sous le personnage ou la target.
+
+    TARGET SYSTEM:
+        [ ] 250     Differents critères de limitation de l entité Target, selon type : TILE only, CHAR, etc.
 
     CONTROLES:
         [ ] 10     Pouvoir utiliser espace pour Stairs.
@@ -34,8 +38,17 @@ NEXT:
     LOOTS / MONSTRES:
         [ ] 250     Niveau de danger pour modifier un monstre de base selon le niveau du donjon.
         [ ] 250     Table de mobs / items : poids dependant du niveau de danger.
-        [ ] 50      Nom de monstre vs nom de reference du monstre
+        [ ] 50      Nom de monstre vs nom de reference du monstre & idem pour items
         [ ] 50      Pack de monstres, thematique "monstre" de salles.
+        [ ] 100     Items & monstres uniques, ou avec une limite, pour eviter trop grand nombre d'armes en doublon.
+        [ ] 250     Creation d'items par morceaux selon region, chances de magique, budget magique a repartir, etc. affix / suffix and all that.
+        [ ] 100     Creation de monstre par morceaux selon region, etc. cf.items?
+
+    ITEMS :
+        [ ] 50      Drinkable : Potions
+        [ ] 50      Throwable : Acide,
+        [ ] 50      Dropable : Graine, Piege
+        [ ] 50      Readable : Scrolls
 
     FIGHT:
         [ ] 100     Items de baston.
@@ -49,7 +62,7 @@ NEXT:
 
     GAMEPLAY
         [ ] 100     Beat : Tour = 5 beats. Beat Quick, Normal, NoSlow, Fast, Normal.
-        [ ] 250     Equipement, items
+        [/] 250     Equipement, items
         [ ] 250     Throw, drop, Equip
         [ ] 250     IA de pack de mobs, interaction entre eux et partage infos.
         [ ] 50      Reflechir : Game Master pour diriger IA, gerer l'ambiance, les loots, etc?
@@ -59,6 +72,14 @@ NEXT:
     LOCALIZATION
         [ ] 250     Avoir un texte selon le choix de la langue. POC to do.
         [ ] 100     Gerer l'utf8 ou en tout cas ne pas supprimer les mots avec accent. Libtcod ne semble pas suppoorter UTF8.
+
+    IA / GAME MASTER
+        [ ] 250     Remplacer le for entity in entities dans Game turn par une IA globale qui gère les actions des entités.
+        [ ] 100     IA gère les entités via Commands. Dispose du systeme de Move astar etc.
+
+    ANIMATIONS
+        [ ] 100     Animation via Event handler / Listener. Si animations en attente, le game turn les fait tourner avant de rendre la main.
+        [ ] 100     Pouvoir interrompre l'animation ou l'acceler avec Escape.
 
     REFACTOS
         [ ] 100     Entities & co : Pourquoi mettre Game dedans? Comment eviter ca?
@@ -70,6 +91,11 @@ NEXT:
         [ ] 100     L'intelligence de ce qui doit s'afficher repose sur RenderEngine, ce devrait etre App & Game qui lui disent quoi afficher.
         [ ] 100     Faciliter l'ajout et la recuperation des monstres à creer. Numpy?
         [ ] 100     Menu : Si _options avec des entités, et pas de display_options avec texte : crash. Cf inventory.
+        [ ] 100     Creation d'items vs data items.
+        [ ] 50      Refacto Target : devrait etre associé au personnage? If link then command on linked entity?
+        [ ] 250     Listener pour gerer les communications avec Game, App, etc. Remplacerait le Game dans Entité.
+        [ ] 100     Refacto Target System. Pas souple du tout, specifique aux items.
+        [ ] 100     Mieux utiliser les return True / False dans les fonctions, pour dire au moins "j'ai fais ce que tu m'a demandé"
 
     TO LEARN:
         [ ]     Decorator pour entourer les fonctionnalités use_function des items. Le decorateur etait joué dés le main menu,
@@ -79,14 +105,14 @@ NEXT:
 
     OBJECTIFS:
 
-
         # RELEASE 3 : Equipement, items basiques, repartition des monstres & items dans la map selon Facteur Danger.
             [/] Refacto, clean up.
             [ ] Refonte usage des Items.
-            [ ] Equiper et déséquiper des armes.
-            [ ] Items basiques supplementaires.
+            [/] Equiper et déséquiper des armes.
+            [/] Items basiques supplementaires.
             [ ] Actions : Drop, Throw, Drink, Equip
             [ ] Repartition des monstres dans une map sur une base de Facteur Danger.
             [ ] Repartition des items dans une map sur une base Facteur Valeur.
+            [ ] Limite dans les types d'objet ou de monstres pour assurer variété et eviter doublon.
 
         # RELEASE 4 : Maps & generation, salles speciales, meilleures tables de mobs.

--- a/changelogs.txt
+++ b/changelogs.txt
@@ -1,10 +1,19 @@
+v0.0.19
+    Possibilité de dropper un item au sol, via DropMenu.
+    Si item équipé, il est déséquipé mais pas droppé.
+    Systeme de target: une entité '+' est créée et peut être déplacée pour choisir une cible.
+    Target limité à Fov du joueur.
+    Target limité aux items seulement. Contraintes sur la fonction utilisable.
+    TODO: Activer la selection de la cible
+    TODO: Consequence de l'usage de la cible pour l'objet à l'origine du ciblage.
+
 v0.0.18
     Des items peuvent être équipés.
     Les personnages peuvent avoir un equipement.
     Les armes ont leur propre weapon damage, qui remplace celle de base.
     Les objets équipés apparaissent dans le menu inventaire.
     Equipements divers ajoutés.
-
+    Stats de base et modifiées apparaissent dans la fiche du personnage.
 
 v0.0.17
     Clean des GameStates : ils ne sont plus necessaires.

--- a/components/item.py
+++ b/components/item.py
@@ -1,5 +1,5 @@
 class Item:
-    def __init__(self, use_function=None, power=0, **kwargs):
+    def __init__(self, use_function=None, power=0, target_type=None):
         self.use_function = use_function
         self.power = power
-        self.function_kwargs = kwargs
+        self.target_type = target_type

--- a/config/config.py
+++ b/config/config.py
@@ -1,6 +1,6 @@
 def get_app_config():
     configuration = {
-        'version': '0.0.18',
+        'version': '0.0.19',
         'screen_width': 80,
         'screen_height': 50,
         'bar_width': 20,

--- a/config/constants.py
+++ b/config/constants.py
@@ -23,6 +23,7 @@ class ConstColors:
     NO_DAMAGE_ATTACK = libtcod.grey
     # collection
     ITEM_PICKED = libtcod.light_blue
+    ITEM_DROPED = libtcod.light_blue
     INVENTORY_FULL = libtcod.yellow
     NOTHING_TO_PICK_UP = libtcod.yellow
     CANNOT_BE_USED = libtcod.orange
@@ -33,6 +34,8 @@ class ConstColors:
     # Equipement
     UNEQUIP = libtcod.dark_yellow
     EQUIP = libtcod.yellow
+    # Target
+    TARGET_MESS_COLOR = libtcod.yellow
 
 
 class ConstTexts:
@@ -47,6 +50,8 @@ class ConstTexts:
     NOTHING_TO_PICK_UP = 'There is nothing here to pick up.'
     INVENTORY_EMPTY = 'inventory is empty'
     INVENTORY_HEADER = 'Press the key next to an item to use it, or Esc to cancel.\n'
+    DROP_INVENTORY_HEADER = 'Press the key next to an item to drop it, or Esc to cancel.\n'
+    DROP_ITEM = 'You drop {} on the floor.'
     # victory
     VICTORY_LAST_FLOOR_BASIC = 'OUT OF DANGER!! You escape the Cursed Forest!'
     # XP
@@ -64,4 +69,9 @@ class ConstTexts:
     EQUIPMENT_SLOT_OFF_HAND = 'Main Gauche'
     EQUIPMENT_SLOT_NECK = 'Cou'
     EQUIPMENT_SLOT_CHEST = 'Torse'
+    # Target
+    TARGET_MODE_ON = 'You are in target mode.'
+    TARGET_CONTROLS_EXPLAIN = 'Press SPACE to validate, ESC to quit this mode.'
+    TARGET_TYPE_INVALID = 'ERROR: Not valid target type.'
+
 

--- a/data/create_entities.py
+++ b/data/create_entities.py
@@ -127,6 +127,7 @@ def create_entity_item(game, item_defname, x, y, dict_attributes):
     use_function = dict_attributes.get('use_function', None)
     power = dict_attributes.get('power', 0)
     equippable = dict_attributes.get('equippable', False)
+    target = dict_attributes.get('target', None)
 
     if equippable:
         equippable_slot = equippable.get('slot', EquipmentSlot.NONE)
@@ -145,7 +146,7 @@ def create_entity_item(game, item_defname, x, y, dict_attributes):
     else:
         equippable_component = None
 
-    item_component = Item(use_function=use_function, power=power)
+    item_component = Item(use_function=use_function, power=power, target_type=target)
     item = Entity(game, x, y,
                   appearance, color, name,
                   item=item_component,

--- a/data/item_table.py
+++ b/data/item_table.py
@@ -1,25 +1,37 @@
 def get_item_table(map_type):
     tables = {
         'standard_map': {
-            'healing potion': 10,
-            'greater healing potion': 3
-        },
-        'forest_map': {
-            'healing potion': 16,
-            'greater healing potion': 5,
+            'healing_potion': 16,
             'staff': 10,
             'bracelet': 5,
             'staff_force': 3,
             'talisman': 5,
             'robe': 8
         },
+        'forest_map': {
+            'healing_potion': 320,
+            'staff': 10,
+            'bracelet': 5,
+            'staff_force': 3,
+            'talisman': 5,
+            'robe': 8,
+            'grease_potion': 10
+        },
         'old_forest': {
-            'healing potion': 15,
-            'greater healing potion': 3
+            'healing_potion': 34,
+            'staff': 5,
+            'bracelet': 8,
+            'staff_force': 5,
+            'talisman': 8,
+            'robe': 6
         },
         'thorns': {
-            'healing potion': 20,
-            'greater healing potion': 10
+            'healing_potion': 40,
+            'staff': 2,
+            'bracelet': 6,
+            'staff_force': 10,
+            'talisman': 6,
+            'robe': 9
         }
     }
     try:

--- a/data/items.py
+++ b/data/items.py
@@ -1,23 +1,26 @@
 import libtcodpy as libtcod
-from effect_functions import heal
+from effect_functions import heal, grease
 from components.equippable import EquipmentSlot
+from systems.target_selection import TargetType
 
 
 def get_item_attributes(item):
     item_compendium = {
-        'healing potion': {
+        'healing_potion': {
             'name': 'Potion de soins',
             'char': '!',
             'color': libtcod.violet,
             'use_function': heal,
-            'power': 4
+            'power': 8,
+            'target': TargetType.SELF
         },
-        'greater healing potion': {
-            'name': 'Potion de soins superieurs',
+        'grease_potion': {
+            'name': 'Potion de graisse',
             'char': '!',
             'color': libtcod.violet,
-            'use_function': heal,
-            'power': 12
+            'use_function': grease,
+            'power': 8,
+            'target': TargetType.OTHER
         },
         'staff': {
             'name': 'Baton de voyageur',

--- a/data/monster_table.py
+++ b/data/monster_table.py
@@ -5,30 +5,30 @@ def get_monster_table(map_type):
             'living root': 3
         },
         'forest_map': {
-            'ougloth_weak': 10,
-            'ougloth': 10,
+            'ougloth_weak': 30,
+            'ougloth': 15,
             'living_root': 10,
             'charencon': 1,
-            'gob_dog': 9,
+            'gob_dog': 10,
             'murderous_root': 10
         },
         'old_forest': {
-            'ougloth_weak': 7,
-            'ougloth': 13,
-            'ougloth_brute': 3,
+            'ougloth_weak': 22,
+            'ougloth': 30,
+            'ougloth_brute': 5,
             'living_root': 7,
             'charencon': 2,
-            'gob_dog': 9,
-            'murderous_root': 9
+            'gob_dog': 20,
+            'murderous_root': 20
         },
         'thorns': {
-            'ougloth_weak': 5,
-            'ougloth': 14,
-            'ougloth_brute': 6,
-            'living_root': 3,
-            'charencon': 3,
-            'gob_dog': 9,
-            'murderous_root': 10
+            'ougloth_weak': 16,
+            'ougloth': 22,
+            'ougloth_brute': 10,
+            'living_root': 5,
+            'charencon': 4,
+            'gob_dog': 15,
+            'murderous_root': 15
         }
     }
     try:

--- a/effect_functions.py
+++ b/effect_functions.py
@@ -2,17 +2,19 @@ from config.constants import ConstColors, ConstTexts
 
 
 # TODO: texte "heal" dans l'objet, peut etre plutot dans l'effet de la potion (Sur Fighter?)
-def heal(*args, **kwargs):
-    print('effect : heal : args, kwargs ', *args, **kwargs)
-    entity = args[0]
-    power = args[1]
+def heal(user, power, target):
 
-    if entity.fighter.hp == entity.fighter.max_hp:
+    if target.fighter.hp == target.fighter.max_hp:
         return {'consume_item': False,
                 'message': ConstTexts.FULL_HEAL_ALREADY,
                 'color': ConstColors.FULL_HEAL_ALREADY}
     else:
-        entity.fighter.heal(power)
+        target.fighter.heal(power)
         return {'consume_item': True,
                 'message': ConstTexts.WOUND_HEALED,
                 "color": ConstColors.WOUND_HEALED}
+
+
+def grease(user, power, target):
+    print('effect: grease: args, kwargs ')
+

--- a/engine.py
+++ b/engine.py
@@ -60,8 +60,12 @@ class App:
     def exit_window(self):
         # Menus in game
         if self.app_states == AppStates.GAME:
+            # v0.0.19
+            if self.game.target_mode:
+                self.game.quit_target_mode()
+
             # Si pas de menu, on propose de quitter
-            if not self.game.current_menu:
+            elif not self.game.current_menu:
                 self.game.current_menu = QuitMenu(self)
             # Si menu, avec back to main quand on exit
             elif self.game.current_menu.back_to_main:

--- a/entities.py
+++ b/entities.py
@@ -62,6 +62,7 @@ class Entity:
         self.round += 1
 
     def wait(self):
+        print('wait: {}, round {}'.format(self.name, self.round))
         self.end_turn()
 
     def pick_up(self):

--- a/game.py
+++ b/game.py
@@ -6,6 +6,8 @@ from data.data_loaders import save_game
 from map_objects.dungeon import Dungeon
 from utils.fov_functions import initialize_fov
 import libtcodpy as libtcod
+# v0.0.19
+from systems.target_selection import Target
 
 
 class Game:
@@ -21,6 +23,9 @@ class Game:
         self.dungeon = None
         self.current_menu = None
         self.round = 1
+        # v0.0.19
+        self.target_mode = False
+        self.target = None
 
     def initialize(self):
         # recuperation de la config.
@@ -42,6 +47,20 @@ class Game:
 
         self.full_recompute_fov()
 
+    # v0.0.19
+    def close_menu(self):
+        self.current_menu = None
+
+    def activate_target_mode(self, target_source, target_type):
+        self.close_menu()
+        self.target_mode = True
+        self.target = Target(self.player, self, target_source, target_type)
+
+    def quit_target_mode(self):
+        self.dungeon.current_map.remove_entity(self.target)
+        self.target = None
+        self.target_mode = False
+
     def recompute_fov(self):
         recompute_fov(self.dungeon.current_map.fov_map, self.player.x, self.player.y, self.player.fov_radius,
                       self.player.light_walls, self.fov_algorithm)
@@ -61,7 +80,10 @@ class Game:
 
     def game_turn(self):
         if self.player.round <= self.round:
-            self.player_turn()
+            if self.target_mode:
+                self.events.resolve_events()
+            else:
+                self.player_turn()
         else:
             self.enemy_turn()
             self.new_round()

--- a/handlers/event_handler.py
+++ b/handlers/event_handler.py
@@ -25,6 +25,8 @@ class EventHandler:
             color = event.get('color')
             victory = event.get('victory')      # True
             level_up = event.get('level_up')    # Entity
+            quit_target_mode = event.get('quit_target_mode')    # True
+            function_to_play = event.get('function_to_play')    # function
 
             if not color:
                 color = ConstColors.NEUTRAL_INFO_COLOR
@@ -37,6 +39,12 @@ class EventHandler:
 
             if level_up:
                 self.game.current_menu = LevelUpMenu(level_up)
+
+            if quit_target_mode:
+                self.game.quit_target_mode()
+
+            if function_to_play:
+                function_to_play()
 
         self.reset_event_list()
 

--- a/handlers/input_handlers.py
+++ b/handlers/input_handlers.py
@@ -49,12 +49,17 @@ class InputHandler:
             return 'button_i'
         elif key_char == 'c':
             return 'button_c'
+        elif key_char == 'd':
+            return 'button_d'
 
         if key.vk == libtcod.KEY_ESCAPE:
             return 'button_escape'
 
         if key.vk == libtcod.KEY_ENTER and key.lalt:
             return 'button_alt_enter'
+
+        if key.vk == libtcod.KEY_SPACE:
+            return 'button_space'
 
         return
 
@@ -77,6 +82,10 @@ class InputHandler:
             return 'show_inventory'
         elif key == 'button_c':
             return 'character_screen'
+        elif key == 'button_d':
+            return 'drop_menu'
+        elif key == 'button_space':
+            return 'validate_target'
 
         if key == 'button_alt_enter':
             return 'full_screen'
@@ -91,24 +100,38 @@ class InputHandler:
         else:
             cmd = cmd.strip().lower()
             if self.app.app_states == AppStates.GAME and not self.app.game.current_menu:
+                if not self.app.game.target_mode:
+                    obj = self.app.game.player
+                else:
+                    obj = self.app.game.target
+
+                # On char or Target
                 if cmd == 'move_up':
-                    self.user_command_controller.execute(MoveUpCommand(self.app.game.player))
+                    self.user_command_controller.execute(MoveUpCommand(obj))
+                # On char or Target
                 elif cmd == 'move_down':
-                    self.user_command_controller.execute(MoveDownCommand(self.app.game.player))
+                    self.user_command_controller.execute(MoveDownCommand(obj))
+                # On char or Target
                 elif cmd == 'move_left':
-                    self.user_command_controller.execute(MoveLeftCommand(self.app.game.player))
+                    self.user_command_controller.execute(MoveLeftCommand(obj))
+                # On char or Target
                 elif cmd == 'move_right':
-                    self.user_command_controller.execute(MoveRightCommand(self.app.game.player))
+                    self.user_command_controller.execute(MoveRightCommand(obj))
+                # On char or Target
                 elif cmd == 'wait':
-                    self.user_command_controller.execute(WaitCommand(self.app.game.player))
+                    self.user_command_controller.execute(WaitCommand(obj))
                 elif cmd == 'pick_up':
-                    self.user_command_controller.execute(PickUpCommand(self.app.game.player))
+                    self.user_command_controller.execute(PickUpCommand(obj))
                 elif cmd == 'take_stairs':
-                    self.user_command_controller.execute(TakeStairsCommand(self.app.game.player))
+                    self.user_command_controller.execute(TakeStairsCommand(obj))
                 elif cmd == 'show_inventory':
-                    self.user_command_controller.execute(ShowInventory(self.app.game.player.inventory))
+                    self.user_command_controller.execute(ShowInventory(obj))
                 elif cmd == 'character_screen':
-                    self.user_command_controller.execute(ShowCharacterScreen(self.app.game.player.level))
+                    self.user_command_controller.execute(ShowCharacterScreen(obj))
+                elif cmd == 'drop_menu':
+                    self.user_command_controller.execute(DropMenu(obj))
+                elif cmd == 'validate_target':
+                    self.user_command_controller.execute(ValidateTarget(obj))
 
             if cmd == 'exit_window':
                 self.user_command_controller.execute(ExitWindow(self.app))

--- a/map_objects/map.py
+++ b/map_objects/map.py
@@ -47,6 +47,12 @@ class GameMap:
     def add_entity(self, entity):
         self.entities.append(entity)
 
+    def remove_entity(self, entity):
+        try:
+            self.entities.remove(entity)
+        except:
+            print('Entity {} not present in map.entities but removal requested.'.format(entity))
+
     def _initialize_tiles(self):
         tiles = [[Tile(True) for y in range(self.height)] for x in range(self.width)]
 
@@ -128,7 +134,7 @@ class GameMap:
                 num_rooms += 1
 
         stairs_component = Stairs(self.dungeon.current_floor + 1)
-        down_stairs = Entity(self.dungeon.game, center_last_room_x, center_last_room_y, '>', libtcod.white, 'Stairs',
+        down_stairs = Entity(self.dungeon.game, center_last_room_x, center_last_room_y, '>', libtcod.yellow, 'Stairs',
                              render_order=RenderOrder.STAIRS, stairs=stairs_component)
         self.entities.append(down_stairs)
 

--- a/render_engine.py
+++ b/render_engine.py
@@ -9,6 +9,7 @@ class RenderOrder(Enum):
     STAIRS = 2
     ITEM = 3
     ACTOR = 4
+    TARGET = 5
 
 
 class Render:

--- a/systems/commands.py
+++ b/systems/commands.py
@@ -1,3 +1,6 @@
+from systems.target_selection import Target
+
+
 class CommandController:
     def __init__(self):
         self.history = []
@@ -31,15 +34,30 @@ class ExitWindow(Command):
 # LEVEL
 class ShowCharacterScreen(Command):
     def execute(self):
-        self._obj.show_character_screen()
+        if self._obj.level:
+            self._obj.level.show_character_screen()
 
+
+# TARGET
+class ValidateTarget(Command):
+    def execute(self):
+        if isinstance(self._obj, Target):
+            self._obj.validate_target()
 
 # INVENTORY
 class ShowInventory(Command):
     def execute(self):
-        self._obj.show_inventory()
+        if self._obj.inventory:
+            self._obj.inventory.show_inventory('use')
 
 
+class DropMenu(Command):
+    def execute(self):
+        if self._obj.inventory:
+            self._obj.inventory.show_inventory('drop')
+
+
+# CHARACTER
 class MoveUpCommand(Command):
     def execute(self):
         self._obj.try_to_move(0, -1)
@@ -67,7 +85,8 @@ class WaitCommand(Command):
 
 class PickUpCommand(Command):
     def execute(self):
-        self._obj.pick_up()
+        if self._obj.inventory:
+            self._obj.inventory.pick_up()
 
 
 class TakeStairsCommand(Command):

--- a/systems/target_selection.py
+++ b/systems/target_selection.py
@@ -1,0 +1,73 @@
+from render_engine import RenderOrder
+from entities import Entity
+import libtcodpy as libtcod
+from config.constants import ConstTexts, ConstColors
+
+
+class TargetType:
+    NONE = 0
+    SELF = 1
+    OTHER = 2
+
+
+class Target(Entity):
+    def __init__(self, player, game, target_source, target_type):
+        super().__init__(game, player.x, player.y, '+', libtcod.white, 'Target')
+        self.target_source = target_source
+        self.function_on_validate = target_source.use_function
+        self.player = player
+        self.game_map = game.dungeon.current_map
+        self.render_order = RenderOrder.TARGET
+        self.target_type = target_type
+
+        if self.target_type == TargetType.NONE:
+            self.game.events.add_event({'message': ConstTexts.TARGET_TYPE_INVALID,
+                                        'color': ConstColors.TARGET_MESS_COLOR})
+            self.quit_target_mode()
+        else:
+            # Je m'ajoute pour être visible.
+            self.game_map.add_entity(self)
+            self.warning()
+
+    def quit_target_mode(self):
+        self.game.events.add_event({'quit_target_mode': True})
+
+    def warning(self):
+        self.game.events.add_event({'message': ConstTexts.TARGET_MODE_ON, 'color': ConstColors.TARGET_MESS_COLOR})
+        self.game.events.add_event({'message': ConstTexts.TARGET_CONTROLS_EXPLAIN,
+                                    'color': ConstColors.TARGET_MESS_COLOR})
+
+    def validate_target(self):
+        self.game.events.add_event({'message': 'You validate something', 'color': ConstColors.TARGET_MESS_COLOR})
+        self.game.events.add_event({'function_to_play': self.function_on_validate(self.player,
+                                                                                  self.target_source.power,
+                                                                                  self.player)})
+        self.quit_target_mode()
+
+    def wait(self):
+        self.warning()
+        self.player.wait()
+        # super().wait()
+
+    def move(self, dx, dy):
+        # Move the entity by a given amount
+        self.x += dx
+        self.y += dy
+
+    def try_to_move(self, dx, dy):
+        destination_x = self.x + dx
+        destination_y = self.y + dy
+        if libtcod.map_is_in_fov(self.game_map.fov_map, destination_x, destination_y):
+            self.move(dx, dy)
+
+    def interact_with_entity(self, entity):
+        raise NotImplementedError
+
+    def move_towards(self, target_x, target_y):
+        raise NotImplementedError
+
+    def distance_to(self, other):
+        raise NotImplementedError
+
+    def move_astar(self, game_map, target):
+        raise NotImplementedError


### PR DESCRIPTION
    Possibilité de dropper un item au sol, via DropMenu.
    Si item équipé, il est déséquipé mais pas droppé.
    Systeme de target: une entité '+' est créée et peut être déplacée pour choisir une cible.
    Target limité à Fov du joueur.
    Target limité aux items seulement. Contraintes sur la fonction utilisable.
    TODO: Activer la selection de la cible
    TODO: Consequence de l'usage de la cible pour l'objet à l'origine du ciblage.