### PR TITLE
v0.0.21 : Fixes and refactos

### DIFF
--- a/Docs/roadmap.md
+++ b/Docs/roadmap.md
@@ -1,6 +1,6 @@
 NEXT:
     DONGEON:
-        [ ] 100     Ajouter des fonctions get_entities_from_map? Pour meilleur accès aux infos dans la map pour game?
+        [/] 100     Ajouter des fonctions get_entities_from_map? Pour meilleur accès aux infos dans la map pour game?
         [ ] 250     Tile personnalisée pour l'affichage : Char, couleurs selon la tile et non pas au niveau de la map.
         [ ] 250     'Salles' avec evenements-types & variantes.
         [ ] 50      monster_table pas utilisé dans les specs des maps de donjon.
@@ -11,7 +11,7 @@ NEXT:
     INTERFACE:
         [ ] 250     Meilleure communication des actions possibles + boutons (ex: perso sur item : "(g) pick up {item}"
         [ ] 250     Afficher les objets et les personnages "en vue" avec description dans l'interface.
-        [/] 100     Afficher items equipés dans menu Inventaire & Character?
+        [/] 100     Afficher items equipés dans menu Inventaire & bonus Character?
         [ ] 100     Afficher les caracts des items equipés.
         [ ] 100     Afficher les objets sous le personnage ou la target.
 
@@ -23,18 +23,19 @@ NEXT:
         [/] 10      Pouvoir utiliser espace.
         [ ] 50      mouse : deplacements souris
         [ ] 100     Permettre de definir controles par le joueur.
-        [ ] 100     FIX: Quand inventaire reclamé via 'i', le menu est aussitot activé avec la touche 'i'. Idem Char screen, etc.
+        [/] 100     FIX: Quand inventaire reclamé via 'i', le menu est aussitot activé avec la touche 'i'. Idem Char screen, etc.
 
     INVENTORY:
         [/] 100     use inventory : Nawak, tout se melange entre game pour l'usage, iventory pour le consume, etc.
 
-    MAKE_MAP:
+    MAP:
         [ ] 100    tofix : Map peut être hors index, en tout cas sans bord pour bloquer le passage
                       >(Genre : case non bloqué sur le bord : j'avance, crash car hors index).
                       > Probablement du à l'effet sur les corridors de 1 tile supp de large
-        [ ] 100    Rendre les salles moins carrés.
-        [ ] 50     Animation au changement de map.
-        [ ]100     Garder la salle de transition d'une map à l'autre, illustre mieux le fait qu'on soit dans la meme foret.
+        [ ] 100     Rendre les salles moins carrés.
+        [ ] 50      Animation au changement de map.
+        [ ] 100     Garder la salle de transition d'une map à l'autre, illustre mieux le fait qu'on soit dans la meme foret.
+        [ ] 250     Elements de map pouvant être detruits. Structure & resistance selon type Tuile. Attributs sur Tuile seulement une fois touché, sinon dans le type.
 
     LOOTS / MONSTRES:
         [ ] 250     Niveau de danger pour modifier un monstre de base selon le niveau du donjon.
@@ -49,9 +50,10 @@ NEXT:
         [/] 50      Drinkable : Potions
         [/] 50      Throwable : Acide,
         [ ] 50      Dropable : Graine, Piege
-        [ ] 50      Readable : Scrolls
+        [ ] 50      Readable : Scrolls, notes pour ambiance
         [ ] 100     Message selon l'usage : '{} lance {}', '{} boit {}'
         [ ] 250     Pouvoir faire un usage creatif des autres modes. Actuellement : Potion tjrs drink. Concept unique de "use"
+        [ ] 250     Items avec structure & resistance, pouvant être detruits.
 
     FIGHT:
         [/] 100     Items basiques de baston.
@@ -93,7 +95,7 @@ NEXT:
 
     REFACTOS
         [ ] 100     Entities & co : Pourquoi mettre Game dedans? Comment eviter ca?
-        [/] 100     Inventory: use item : wrapper les fonctions effects par un item_use pour meilleur controle et garder les Effets plus neutres (utilisable par sort & etc).
+        [/] 100     Inventory: use item : wrapper les fonctions effects par un item_use pour meilleur controle et garder les Effets plus neutres (utilisable par sort & etc)?
         [ ] 50      render : solution degueu du reset game window pour artefacts map precedente.
         [ ] 50      map_is_in_fov testé dans enemy turn avant action et dans ai: take_turn. Doublon? Logique?
         [ ] 100     map.entities contient toutes les entités. Si on veut deplacer mob, on trouve des items. Si on veut recuperer des items, on passe par des entités.
@@ -109,6 +111,7 @@ NEXT:
         [ ] 100     Mieux utiliser les return True / False dans les fonctions, pour dire au moins "j'ai fais ce que tu m'a demandé"
         [ ] 50      Refacto effect functions / inventory / items : le message "{} thrown at {}" est dans effet. Devrait etre ailleurs.
         [/] 50      Target Self devrait être dans le systeme de targeting, pas inventory.
+        [ ] 250     Fonctions de combat hors Fighter : rends Fighter plus clean, permets de les utiliser sur les items et map.
 
     TO LEARN:
         [ ]     Decorator pour entourer les fonctionnalités use_function des items. Le decorateur etait joué dés le main menu,

--- a/changelogs.txt
+++ b/changelogs.txt
@@ -1,3 +1,10 @@
+v0.0.21
+    Le bord des maps est desormais indestructibles, empechant les incidents de hors map possibles avec crash.
+    Refacto : accès à certains parametres de game_map via spawner et autres.
+    Le passage vers le niveau suivant se trouve desormais dans la salle la plus eloignée.
+    Fix : Crash à l'usage d'un item avec target Self.
+    Fix : Les touches commandant un menu ne selectionne plus l'option associée à cette touche en même temps.
+
 v0.0.20
     Le ciblage se valide avec Space et retourne les entités fighter et items de la position selectionnée.
     Si cible corresponds au type attendu, la fonction à l'origine du ciblage est jouée.

--- a/config/config.py
+++ b/config/config.py
@@ -1,6 +1,6 @@
 def get_app_config():
     configuration = {
-        'version': '0.0.20',
+        'version': '0.0.21',
         'screen_width': 80,
         'screen_height': 50,
         'bar_width': 20,

--- a/data/monster_table.py
+++ b/data/monster_table.py
@@ -6,29 +6,28 @@ def get_monster_table(map_type):
         },
         'forest_map': {
             'ougloth_weak': 30,
-            'ougloth': 15,
+            'ougloth': 5,
             'living_root': 10,
-            'charencon': 1,
             'gob_dog': 10,
             'murderous_root': 10
         },
         'old_forest': {
-            'ougloth_weak': 22,
-            'ougloth': 30,
-            'ougloth_brute': 5,
-            'living_root': 7,
-            'charencon': 2,
+            'ougloth_weak': 20,
+            'ougloth': 10,
+            'ougloth_brute': 3,
+            'living_root': 4,
+            'charencon': 1,
             'gob_dog': 20,
             'murderous_root': 20
         },
         'thorns': {
-            'ougloth_weak': 16,
-            'ougloth': 22,
-            'ougloth_brute': 10,
-            'living_root': 5,
-            'charencon': 4,
-            'gob_dog': 15,
-            'murderous_root': 15
+            'ougloth_weak': 14,
+            'ougloth': 20,
+            'ougloth_brute': 6,
+            'living_root': 2,
+            'charencon': 2,
+            'gob_dog': 14,
+            'murderous_root': 14
         }
     }
     try:

--- a/handlers/input_handlers.py
+++ b/handlers/input_handlers.py
@@ -9,23 +9,27 @@ class InputHandler:
         self.app = app
         self.user_command_controller = command_controller
 
-    def press(self, key):
-        # key comes from libtcod.
-        converted_key = self.convert_libtcod_to_key(key)
-        command_key = self.get_command_from_key(converted_key)
-        self.command_requested(command_key)
-
+    def get_current_menu(self):
         current_menu = None
-
         if self.app.game and self.app.game.current_menu:
             current_menu = self.app.game.current_menu
         elif self.app.current_menu:
             current_menu = self.app.current_menu
 
+        return current_menu
+
+    def press(self, key):
+        current_menu = self.get_current_menu()
+        # key comes from libtcod.
+        converted_key = self.convert_libtcod_to_key(key)
+        command_key = self.get_command_from_key(converted_key)
+
         if current_menu:
             index = key.c - ord('a')
             if index >= 0:
                 current_menu.receive_option_choice(index)
+
+        self.command_requested(command_key)
 
     def convert_libtcod_to_key(self, key):
         key_char = chr(key.c)

--- a/map_objects/map.py
+++ b/map_objects/map.py
@@ -8,6 +8,7 @@ from entities import Entity
 import libtcodpy as libtcod
 from render_engine import RenderOrder
 
+import math
 from random import randint
 
 
@@ -33,43 +34,109 @@ class GameMap:
 
         # On créé une map pleine, non utilisable sans sa generation.
         self.tiles = self._initialize_tiles()   # tiles = la vraie map
+        self._make_indestructible_barriers()    # Tiles indestructibles autour.
         self.fov_map = None
 
-        self.rooms = []
+        self._rooms = []
         self.entities = []
+        self._player = None
+        self._items = []
+        self._fighters = []
 
         # On genere un spawner, pour gerer le placement des mobs & items.
         self.spawner = Spawner(self, max_monsters_room_table, max_items_room_table)
 
+    # ADD & GET.
     def add_player(self, player):
         self.entities.append(player)
+        self._player = player
+
+    def add_entity(self, entity):
+        self.entities.append(entity)
+
+    def add_item(self, entity_item):
+        self._items.append(entity_item)
+        self.add_entity(entity_item)
+
+    def add_fighters(self, entity_fighter):
+        self._fighters.append(entity_fighter)
+        self.add_entity(entity_fighter)
+
+    def add_room(self, room):
+        self._rooms.append(room)
 
     def get_entities(self):
         return self.entities
 
-    def add_entity(self, entity):
-        self.entities.append(entity)
+    def get_items(self):
+        return self._items
+
+    def get_fighters(self):
+        return self._fighters
+
+    def get_rooms(self):
+        return self._rooms
 
     def remove_entity(self, entity):
         try:
             self.entities.remove(entity)
         except:
-            print('Entity {} not present in map.entities but removal requested.'.format(entity))
+            raise IndexError
 
+    def remove_item(self, item):
+        if item.item:   # component Item
+            try:
+                self._items.remove(item)
+                self.remove_entity(item)
+            except:
+                raise IndexError
+        else:
+            raise AssertionError
+
+    def remove_fighter(self, fighter):
+        if fighter.fighter:
+            try:
+                self._fighters.remove(fighter)
+                self.remove_entity(fighter)
+            except:
+                raise IndexError
+        else:
+            raise AssertionError
+
+    # MAP CREATION
     def _initialize_tiles(self):
         tiles = [[Tile(True) for y in range(self.height)] for x in range(self.width)]
 
+        for x in range(self.width):
+            for y in range(self.height):
+                pass
+
         return tiles
+
+    def _make_indestructible_barriers(self):
+        for y in range(0, self.height):
+            self.tiles[0][y].destructible = False
+            self.tiles[self.width - 1][y].destructible = False
+
+        for x in range(0, self.width):
+            self.tiles[x][0].destructible = False
+            self.tiles[x][self.height - 1].destructible = False
 
     def is_blocked(self, x, y):
         if self.tiles[x][y].blocked:
             return True
         return False
 
+    def is_indestructible(self, x, y):
+        if self.tiles[x][y].destructible:
+            return False
+        return True
+
     # On genere la map. # TODO : Pouvoir choisir la methode, selon que ce soit caverne, donj, etc.
     def generate_map(self, player):
         # La map en elle meme.
         self._make_map_tutorial_method(player)
+        self.place_stairs()
         # Ce qui est visible ou non du joueur.
         self.fov_map = initialize_fov(self)
         # On spawn les entités qui la peuplent.
@@ -81,8 +148,10 @@ class GameMap:
         rooms = []
         num_rooms = 0
 
+        '''
         center_last_room_x = None
         center_last_room_y = None
+        '''
 
         for r in range(self.max_rooms):
             # random width and height
@@ -107,9 +176,11 @@ class GameMap:
 
                 # center coordinates of new room, will be useful later
                 (new_x, new_y) = new_room.center()
+                '''
                 # we want to know the last created room for the stairs.
                 center_last_room_x = new_x
                 center_last_room_y = new_y
+                '''
 
                 if num_rooms == 0:
                     # this is the first room, where the player starts at
@@ -136,20 +207,50 @@ class GameMap:
                 rooms.append(new_room)
                 num_rooms += 1
 
+        for room in rooms:
+            self.add_room(room)
+
+    def place_stairs(self):
+        player_room = self.get_rooms()[0]
+        farest_room = None
+        farest_distance = 0
+        for room in self.get_rooms():
+            if room != player_room:
+                distance = self.distance_room_to_room(player_room, room)
+                if distance >= farest_distance:
+                    print('farest distance : {} - room {}'.format(distance, room))
+                    farest_distance = distance
+                    farest_room = room
+            else:
+                continue
+
+        center_room_x, center_room_y = farest_room.center()
+
         stairs_component = Stairs(self.dungeon.current_floor + 1)
-        down_stairs = Entity(self.dungeon.game, center_last_room_x, center_last_room_y, '>', libtcod.yellow, 'Stairs',
+        down_stairs = Entity(self.dungeon.game, center_room_x, center_room_y, '>', libtcod.yellow, 'Stairs',
                              render_order=RenderOrder.STAIRS, stairs=stairs_component)
         self.entities.append(down_stairs)
 
-        self.rooms.extend(rooms)
+    # exist also in Entities
+    def distance_room_to_room(self, room, other):
+        dx1, dy1 = room.center()
+        dx2, dy2 = other.center()
+
+        dx = dx1 - dx2
+        dy = dy1 - dy2
+
+        return math.sqrt(dx ** 2 + dy ** 2)
 
     # creation d une salle. # TODO: Aujourd'hui, forcement un Rectangle. Personnalisable à faire?
     def create_room(self, room):
         # go through the tiles in the rectangle and make them passable
         for x in range(room.x1 + 1, room.x2):
             for y in range(room.y1 + 1, room.y2):
-                self.tiles[x][y].blocked = False
-                self.tiles[x][y].block_sight = False
+                if self.tiles[x][y].destructible:
+                    self.tiles[x][y].blocked = False
+                    self.tiles[x][y].block_sight = False
+                else:
+                    print('tile {},{} is indestructible : {}'.format(x, y, self.tiles[x][y].destructible))
 
     # tunnel horizontal, partant d'un point x1 vers un point x2, en restant sur l'horizon y
     # legere variété pour ne pas avoir un couloir de 1 tuile.   # TODO : rendre configurable, avec %
@@ -162,8 +263,11 @@ class GameMap:
             elif rand < -3:
                 rand = -3
             for i in range(min(0, rand), max(0, rand) + 1):
-                self.tiles[x][y + i].blocked = False
-                self.tiles[x][y + i].block_sight = False
+                if self.tiles[x][y + i].destructible:
+                    self.tiles[x][y + i].blocked = False
+                    self.tiles[x][y + i].block_sight = False
+                else:
+                    print('self tile is indestructible')
 
     # tunnel vertical, partant de y1 vers y2, en restant sur vertical x.
     # legere variété pour ne pas avoir un couloir de 1 tuile.   # TODO : rendre configurable, avec %
@@ -176,5 +280,8 @@ class GameMap:
             elif rand < -3:
                 rand = -3
             for i in range(min(0, rand), max(0, rand) + 1):
-                self.tiles[x + i][y].blocked = False
-                self.tiles[x + i][y].block_sight = False
+                if self.tiles[x + i][y].destructible:
+                    self.tiles[x + i][y].blocked = False
+                    self.tiles[x + i][y].block_sight = False
+                else:
+                    print('self tile is indestructible')

--- a/map_objects/tile.py
+++ b/map_objects/tile.py
@@ -1,5 +1,6 @@
 class Tile:
-    def __init__(self, blocked, block_sight=None, explored=False):
+    def __init__(self, blocked, block_sight=None, explored=False, destructible=True):
+        self.destructible = destructible
         self.blocked = blocked
 
         if block_sight is None:

--- a/spawners.py
+++ b/spawners.py
@@ -14,6 +14,10 @@ class Spawner:
         self.monsters_table = get_monster_table(self.map_owner.map_type)
         self.items_table = get_item_table(self.map_owner.map_type)
 
+    # ADD & GET
+    def _get_rooms(self):
+        return self.map_owner.get_rooms()
+
     # table : [[nb_max, level],[nb_max, level + x]]
     # On donne le max, selon le niveau.
     # On retourne le bon nombre que l'on souhaite.
@@ -31,7 +35,8 @@ class Spawner:
             return True
 
     def spawn_entities(self):
-        for room in self.map_owner.rooms:
+        rooms = self._get_rooms()
+        for room in rooms:
             nb_monsters = randint(0, self.max_monsters_room)
 
             for mob in range(nb_monsters):
@@ -54,7 +59,8 @@ class Spawner:
         return None
 
     def spawn_items(self):
-        for room in self.map_owner.rooms:
+        rooms = self._get_rooms()
+        for room in rooms:
             nb_items = randint(0, self.max_items_room)
             for item in range(nb_items):
                 x = randint(room.x1 + 1, room.x2 - 1)

--- a/stuff.py
+++ b/stuff.py
@@ -1,0 +1,45 @@
+HEIGHT = 20
+WIDTH = 10
+
+
+class Test:
+    def __init__(self, destructible=True):
+        self.destructible = destructible
+
+    def __repr__(self):
+        if self.destructible:
+            return '-'
+        else:
+            return '+'
+
+class TestMap:
+    def __init__(self):
+        self.tiles = create_map()
+
+    def __repr__(self):
+        game_map = ''
+        for x in self.tiles:
+            game_map += str(x) + '\n'
+
+        return game_map
+
+    def _make_undestructible_barriers(self):
+        # pour toutes les tuiles de x 0 et x Final.
+        for y in range(0, HEIGHT):
+            self.tiles[0][y].destructible = False
+            self.tiles[WIDTH - 1][y].destructible = False
+
+        for x in range(0, WIDTH):
+            self.tiles[x][0].destructible = False
+            self.tiles[x][HEIGHT - 1].destructible = False
+
+
+def create_map():
+    tiles = [[Test() for y in range(HEIGHT)] for x in range(WIDTH)]
+    return tiles
+
+
+game_map = TestMap()
+print(game_map)
+game_map._make_undestructible_barriers()
+print(game_map)

--- a/systems/target_selection.py
+++ b/systems/target_selection.py
@@ -21,6 +21,8 @@ class Target(Entity):
         self.render_order = RenderOrder.TARGET
         self.target_type = target_type
 
+        self.game_map.add_entity(self)
+
         if self.target_type == TargetType.NONE:
             self.game.events.add_event({'message': ConstTexts.TARGET_TYPE_INVALID,
                                         'color': ConstColors.TARGET_MESS_COLOR})
@@ -29,8 +31,6 @@ class Target(Entity):
             # on lance directement l effet sur soit, sans selection possible.
             self.check_target_against_wanted_type({'entity_fighter': self.player})
         else:
-            # Je m'ajoute pour être visible.
-            self.game_map.add_entity(self)
             self.warning()
 
     def quit_target_mode(self):


### PR DESCRIPTION
    Le bord des maps est desormais indestructibles, empechant les incidents de hors map possibles avec crash.
    Refacto : accès à certains parametres de game_map via spawner et autres.
    Le passage vers le niveau suivant se trouve desormais dans la salle la plus eloignée.
    Fix : Crash à l'usage d'un item avec target Self.
    Fix : Les touches commandant un menu ne selectionne plus l'option associée à cette touche en même temps.